### PR TITLE
SZK-46 Add role to custom claims for user

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,26 +1,45 @@
 from flask import Flask, request
-#import flask_monitoringdashboard as dashboard
+# import flask_monitoringdashboard as dashboard
 from products import products
 from categories import categories
 from flask_cors import CORS
 from flask_firebase_admin import FirebaseAdmin
+from firebase_admin import auth
 
 app = Flask(__name__)
 app.config['JSON_SORT_KEYS'] = False
-#dashboard.bind(app)
+# dashboard.bind(app)
 app.register_blueprint(products)
 app.register_blueprint(categories)
 CORS(app)
 firebase = FirebaseAdmin(app)
 
+
 @app.route("/api/version")
 def version():
     return "1.0"
 
+
 @app.route('/api/v1/whoami', methods=['GET'])
 @firebase.jwt_required
 def whoami():
-    return {"message": f"Hello {request.jwt_payload['email']}!", "paload": request.jwt_payload}
+    uid = request.jwt_payload['uid']
+    user = auth.get_user(uid=uid)
+    role = user.custom_claims["role"]
+    return {"message": f"Hello {request.jwt_payload['email']}!", "payload": request.jwt_payload, "role": role}
+
+
+@app.route('/api/v1/escalatePrivileges', methods=['GET'])
+@firebase.jwt_required
+def escalate_privileges():
+    uid = request.jwt_payload['uid']
+    user = auth.get_user(uid=uid)
+    custom_claims = user.custom_claims
+    custom_claims["role"] = "admin"
+
+    auth.set_custom_user_claims(uid=uid, custom_claims=custom_claims)
+    return {"message": f"You are now admin", "paload": request.jwt_payload}
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,3 +6,4 @@ PyMySQL~=1.0.2
 python-dotenv~=0.21.1
 gunicorn~=20.1.0
 flask-firebase-admin~=0.2.4
+firebase-admin~=6.1.0

--- a/client/src/auth.ts
+++ b/client/src/auth.ts
@@ -1,0 +1,13 @@
+import { asyncComputed } from '@vueuse/core';
+import { useCurrentUser } from 'vuefire';
+
+export type UserRole = 'customer' | 'sales' | 'admin';
+
+export function useCurrentUserRole() {
+  const user = useCurrentUser();
+
+  return asyncComputed<UserRole>(async () => {
+    const result = await user.value?.getIdTokenResult();
+    return result?.claims?.role ?? 'customer';
+  });
+}

--- a/client/src/components/AccountNavbarIcon.vue
+++ b/client/src/components/AccountNavbarIcon.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
+import { useCurrentUserRole } from '@/auth';
 import Popper from "vue3-popper";
 import { useCurrentUser, useFirebaseAuth } from "vuefire";
 
 const user = useCurrentUser();
 const auth = useFirebaseAuth();
+const role = useCurrentUserRole();
 </script>
 
 <template>
-  <div class="ml-4">
+  <div class="flex items-center ml-4">
     <Popper content="Logout" :hover="true" :arrow="true">
       <button @click="auth?.signOut()" class="h-12 cursor-pointer">
         <img :src="user?.photoURL" v-if="user?.photoURL" class="w-auto h-full rounded-full" />
@@ -16,5 +18,9 @@ const auth = useFirebaseAuth();
         </div>
       </button>
     </Popper>
+    <div class="ml-2">
+      <h4>{{ user?.displayName }}</h4>
+      <h5>{{ role }}</h5>
+    </div>
   </div>
 </template>

--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -6,7 +6,6 @@ import LoginNavbarIcon from "./LoginNavbarIcon.vue";
 import ShoppingCartNavbarIcon from "./ShoppingCartNavbarIcon.vue";
 
 const user = useCurrentUser();
-user.value?.getIdToken().then(console.log);
 </script>
 
 <template>


### PR DESCRIPTION
Closes SZK-46 by adding a `role` attribute to the Firebase Auth user object's custom claims
Can be accessed both on the client and server side

Server side:
```
from firebase_admin import auth

...

user = auth.get_user(uid="…")
role = user.custom_claims["role"]
```

Client side:
-> `useCurrentUserRole` from `./auth.ts` as a composable in Vue